### PR TITLE
Bump Gradle wrapper to 5.2.1 to solve issue with Asm

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With Gradle 4.8 is fails at my computer with OpenJDK 11.0.2+7. The stacktrace suggests it's a problem with too old version of asm in Gradle.

```
> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> failed to read class file /home/szpak/Code/reactive-hardcore/build/classes/java/test/org/test/reactive/ArrayPublisherTest.class

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':test'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:110)
...
Caused by: java.lang.UnsupportedOperationException
        at org.objectweb.asm.ClassVisitor.visitNestMemberExperimental(ClassVisitor.java:248)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:651)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:391)
        at org.gradle.api.internal.tasks.testing.detection.AbstractTestFrameworkDetector.classVisitor(AbstractTestFrameworkDetector.java:124)
        ... 67 more
```